### PR TITLE
add blacklist functionality

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${ALFREDJSON_BINARY_DIR}
   ${CMAKE_CURRENT_BINARY_DIR} ${ZLIB_INCLUDE_DIRS} ${JANSSON_INCLUDE_DIRS})
 link_directories(${JANSSON_LIBRARY_DIRS} ${ZLIB_LIBRARY_DIRS})
 
-add_executable(alfred-json main.c output_string.c output_json.c output_binary.c zcat.c)
+add_executable(alfred-json main.c output_string.c output_json.c output_binary.c zcat.c blacklist.c)
 
 set_target_properties(alfred-json PROPERTIES COMPILE_FLAGS "-std=gnu99 -Wall -pedantic" LINK_FLAGS "")
 target_link_libraries(alfred-json ${ZLIB_LIBRARIES} ${JANSSON_LIBRARIES})

--- a/src/blacklist.c
+++ b/src/blacklist.c
@@ -1,0 +1,93 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <netinet/ether.h>
+#include "blacklist.h"
+
+struct mac {
+	uint8_t data[ETH_ALEN];
+};
+
+struct blacklist {
+	struct mac entry;
+	struct blacklist *next;
+};
+
+struct blacklist *blacklist_new() {
+	return calloc(sizeof(struct blacklist), 1);
+}
+
+struct mac *mac_from_string(const char *value) {
+	struct mac *result = calloc(sizeof(struct mac), 1);
+	if (NULL == result)
+		return NULL;
+	if (6 != sscanf(value, "%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 "",
+		&result->data[0], &result->data[1],
+		&result->data[2], &result->data[3],
+		&result->data[4], &result->data[5])) {
+
+		free(result);
+		return NULL;
+	}
+	return result;
+}
+
+struct mac *mac_from_data(const void *value, size_t len) {
+	if (len != ETH_ALEN)
+		return NULL;
+
+	struct mac *result = calloc(sizeof(struct mac), 1);
+	if (NULL == result)
+		return NULL;
+	memcpy(result->data, value, sizeof(result->data));
+	return result;
+}
+
+bool blacklist_is_empty(const struct blacklist *blacklist) {
+	return NULL == blacklist->next;
+}
+
+void blacklist_append(struct blacklist *blacklist, const struct mac *mac) {
+	while (true) {
+		if (NULL == blacklist->next)
+			break;
+		blacklist = blacklist->next;
+	}
+	blacklist->entry = *mac;
+	blacklist->next = blacklist_new();
+}
+
+static inline bool mac_equals(const struct mac *mac1, const struct mac *mac2) {
+	return (0 == memcmp((const void *)mac1, (const void *)mac2, sizeof(struct mac)));
+}
+
+bool blacklist_match(const struct blacklist *blacklist, const struct mac *mac) {
+	while (true) {
+		if (NULL == blacklist->next)
+			break;
+
+		if (mac_equals(mac, &blacklist->entry)) {
+			return true;
+		}
+
+		blacklist = blacklist->next;
+	}
+
+	return false;
+}
+
+size_t blacklist_size(struct blacklist *blacklist) {
+	size_t result = 0;
+
+	while (true) {
+		if (NULL == blacklist->next)
+			break;
+
+		result++;
+		blacklist = blacklist->next;
+	}
+
+	return result;
+}

--- a/src/blacklist.h
+++ b/src/blacklist.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <stdbool.h>
+
+struct blacklist;
+struct mac;
+
+struct mac *mac_from_string(const char *value);
+struct mac *mac_from_data(const void *value, size_t len);
+struct blacklist *blacklist_new();
+size_t blacklist_size(struct blacklist *blacklist);
+void blacklist_append(struct blacklist*, const struct mac *mac);
+bool blacklist_match(const struct blacklist *blacklist, const struct mac *mac);

--- a/src/blacklist.h
+++ b/src/blacklist.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
 
 struct blacklist;
 struct mac;


### PR DESCRIPTION
We see certain hosts submitting invalid data into alfred.
This data makes alfred-json emit a warning twhich in turn triggers cron emails.
The PR adds a simple blacklist functionality to ignore those hosts. This way do not have to suppress all all output from cron json and therefore still receive notifications about other problems.

The patch could use some cleanup which I will perform if I get a general positive feedback.

cc: @christf @oszilloskop @MyIgel
